### PR TITLE
Checks if a configuration template for elastic beanstalk exists or not

### DIFF
--- a/ElasticBeanStalk/Elasticbeanstalk_template_check.py
+++ b/ElasticBeanStalk/Elasticbeanstalk_template_check.py
@@ -1,0 +1,30 @@
+import boto3
+from jmespath import search as search
+import fnmatch
+
+s3 = boto3.client('s3')
+
+def list_buckets():
+	response = s3.list_buckets()
+	return (response)
+
+
+def main():
+    """Check if a bucket exists with elasticbeanstalk as prefix"""
+    
+    a=list_buckets()
+    
+    #list containing names of the bucket
+    bucket_names_list=search('Buckets[*].Name',a)
+    pattern='elasticbeanstalk*'
+    templates = fnmatch.filter(bucket_names_list, pattern)
+    if not templates:
+  		print("Couldn't find a bucket with elasticbeanstalk as perfix, so most probably there are no elasticbeanstalk configuration templates")
+    else:
+    	print("Please check the following buckets. Configuration templates can be found at bucket/resources/templates/app_name \n ")
+    	for buckets in templates:
+    		print(buckets)
+
+
+if __name__ == '__main__':
+    main()

--- a/ElasticBeanStalk/Elasticbeanstalk_template_check.py
+++ b/ElasticBeanStalk/Elasticbeanstalk_template_check.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import boto3
 from jmespath import search as search
 import fnmatch
@@ -5,26 +7,47 @@ import fnmatch
 s3 = boto3.client('s3')
 
 def list_buckets():
-	response = s3.list_buckets()
-	return (response)
+	response 	= s3.list_buckets()
+	return(response)
 
+def getTemplateContents(buckets):
+	"""
+	Fetching contents of ElasticBeanStalk's templates 
+	"""
+
+	appName 	= []
+	tempList 	= []
+	bucketsList = list_buckets()
+	
+	# List containing names of the bucket
+	bucket_names_list	= search('Buckets[*].Name', bucketsList)
+	pattern				= 'elasticbeanstalk*'
+	templates 			= fnmatch.filter(bucket_names_list, pattern)
+	
+	if templates:
+		for buckets in templates:
+			print(f"[#] Bucket: {buckets}")
+			objects 	= search('Contents[*].Key', s3.list_objects(Bucket=buckets))
+
+			for _objs in objects:	
+				if "resources/templates/" in _objs:
+					appName.append(_objs.split("/")[2])
+					tempList.append(f"{templates[0]}/{_objs}")
+
+			for templates in tempList:
+				print(f"[#] Application Name: {appName[0]}")
+				print(f"[#] Template Path: {templates}")
+
+				templateName 	= templates.replace(f'{buckets}/', '')
+				_object 		= s3.get_object(Bucket=buckets, Key=templateName)
+				print(f"[~] Template Contents: \n```\n{search('Body', _object).read().decode()}```\n")
+	
+	else:
+		print("[!] Couldn't find a bucket with elasticbeanstalk as perfix, so most probably there are no elasticbeanstalk configuration templates.")
 
 def main():
-    """Check if a bucket exists with elasticbeanstalk as prefix"""
-    
-    a=list_buckets()
-    
-    #list containing names of the bucket
-    bucket_names_list=search('Buckets[*].Name',a)
-    pattern='elasticbeanstalk*'
-    templates = fnmatch.filter(bucket_names_list, pattern)
-    if not templates:
-  		print("Couldn't find a bucket with elasticbeanstalk as perfix, so most probably there are no elasticbeanstalk configuration templates")
-    else:
-    	print("Please check the following buckets. Configuration templates can be found at bucket/resources/templates/app_name \n ")
-    	for buckets in templates:
-    		print(buckets)
-
+	bucketsList 	= list_buckets()
+	getTemplateContents(bucketsList)
 
 if __name__ == '__main__':
-    main()
+	main()


### PR DESCRIPTION
Checks for s3 buckets that names start with elastic beanstalk as it is the default prefix set to s3 buckets when an elastic beanstalk configuration template is created.